### PR TITLE
feat: Add Sparkbox Safe Focus JS and styles

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,9 +4,14 @@ import Layout from "../components/layout"
 // import Image from "../components/image"
 import HomepageHero from "../components/homepageHero"
 import SEO from "../components/seo"
+import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 
 const IndexPage = () => (
   <Layout lightVersion={true}>
+    <Helmet>
+        <script src={withPrefix('js/safe-focus.js')} type="text/javascript" />
+    </Helmet>
     <SEO title="Home" />
 
     <HomepageHero />

--- a/src/styles/_generic.safe-focus.scss
+++ b/src/styles/_generic.safe-focus.scss
@@ -1,0 +1,11 @@
+// This provides broad, consistent focus styles for elements by default. More
+// specific focus styles can be added to elements on a lower level.
+*:focus {
+  @include focus-styles;
+}
+
+// Since firefox handles focus styles a little bit weirdly on
+// buttons, we need to reapply them with a little more specificity
+button:-moz-focusring {
+  @include focus-styles;
+}

--- a/src/styles/_tools.mixins.scss
+++ b/src/styles/_tools.mixins.scss
@@ -23,7 +23,7 @@
   letter-spacing: 0.02rem;
 
   &:not(:last-child) {
-    margin-bottom: 2rem;  
+    margin-bottom: 2rem;
   }
 
   @media (min-width: $bp-md) {
@@ -38,4 +38,18 @@
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
   white-space: nowrap;
+}
+
+@mixin focus-styles {
+  // Disable native outline since we're drawing our own via box-shadow
+  outline: none;
+
+  html.safe-focus & {
+    // Draws a thick border with a light and dark color for easier readability
+    // for all users. This style is only applied when safe focus is enabled.
+    // Meaning it won't apply unless a user tabs to a focusable element.
+    box-shadow:
+      0 0 0 2px black,
+      0 0 0 4px white !important;
+  }
 }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -21,6 +21,7 @@
   @import "tools.mixins";
 
   // GENERIC
+  @import "generic.safe-focus";
 
   // ELEMENTS
   @import "elements.reset";

--- a/static/js/safe-focus.js
+++ b/static/js/safe-focus.js
@@ -1,0 +1,36 @@
+const safeFocusClass = 'safe-focus';
+const cutsTheMustard = () => !!document.documentElement.classList;
+const htmlEl = document.documentElement;
+
+/* Sparkbox Safe Focus styles */
+
+/**
+ *  Add class to key off of for showing focus outlines
+ *  @return {undefined}
+ */
+const activateSafeFocus = () => {
+  htmlEl.classList.add(safeFocusClass);
+};
+
+/**
+ *  Remove class to key off of for showing focus outlines
+ *  @return {undefined}
+ */
+const deactivateSafeFocus = () => {
+  htmlEl.classList.remove(safeFocusClass);
+};
+
+/**
+ *  Bind events for adding & removing class to key off of for showing focus outlines
+ *  @return {undefined}
+ */
+const initSafeFocus = () => {
+  if (cutsTheMustard()) {
+    htmlEl.classList.remove(safeFocusClass);
+
+    document.addEventListener('mousedown', deactivateSafeFocus);
+    document.addEventListener('keydown', activateSafeFocus);
+  }
+};
+
+initSafeFocus();


### PR DESCRIPTION
- Adds JS to trigger adding a class to the html tag for when focus is applied with keyboard input versus clicking or tabbing.
- Adds special, extra-visible styles to indicate the focused element when using the keyboard to interact with the page.